### PR TITLE
Update readme with installer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Easy Installer for Windows
+You will need administrator privileges for installing Miniconda and the setup script.
+
+1. Download and extract this repo.
+2. Download the model checkpoint. (e.g. from huggingface)
+3. Place the model into 'models\ldm\stable-diffusion-v1' and rename it to 'model.ckpt'.
+4. Download and install Miniconda 3 **for all users.**
+5. Click "Setup Waifu Diffusion".
+6. Change the terminal's directory into the root path of the repo (e.g `cd "C:\Users\Anon\Desktop\stable-diffusion-main"`)
+7. Type the word 'setup' and hit Enter.
+
+After installation has completed, you can click "Launch Waifu Diffusion" to run the program anytime.
+
+---
+
 Environment.yaml working out of the box for k-diffusion, gradio, pynvml, gfpgan
 
 Collection of additional scripts, k-diffusion, gradio, gfpgan etc


### PR DESCRIPTION
now we don't need a rentry anymore

Also, can we have the files needed for textual inversion (found in your other repo) added to this one? Or does that cause compatibility/setup issues?