### PR TITLE
Linux support

### DIFF
--- a/linux-run.sh
+++ b/linux-run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#MIT License
+
+#Copyright (c) 2022 Joshua Kimsey
+
+# Make the file executable if it's not
+chmod 755 ./linux-setup.sh
+
+# Execute the linux-setup.sh file in interactive mode to allow conda to activate properly
+bash -i ./linux-setup.sh

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+
+#MIT License
+
+#Copyright (c) 2022 Joshua Kimsey
+
+
+##### CONDA ENVIRONMENT CREATION AND ACTIVATION #####
+
+# Create The Initial Conda Environment
+# THIS WILL GENERATE AN ERROR IF AN ENVIRONMENT ALREADY EXISTS, THIS SHOULD NOT BE AN ISSUE.
+conda env create -f environment.yaml
+
+# Activate The Conda Environment
+conda activate ldo
+
+
+##### PYTHON HANDLING #####
+
+#Check to see if model exists in the correct location with the correct name, exit if it does not.
+
+FILE=./models/ldm/stable-diffusion-v1/model.ckpt
+if test -f "$FILE"; then
+    python scripts/relauncher.py
+else
+    echo "Your model file does not exist! Place it in 'models\ldm\stable-diffusion-v1' with the name 'model.ckpt'."
+fi

--- a/scripts/relauncher.py
+++ b/scripts/relauncher.py
@@ -6,6 +6,6 @@ while True:
     if n > 0:
         print(f'\tRelaunch count: {n}')
     os.system("python scripts/webui.py")
-    print('Relauncher: Process is ending. Relaunching in 0.5s...')
+    print('Relauncher: Process is ending. Press CTRL-C again to exit fully. Relaunching in 1s...')
     n += 1
-    time.sleep(0.5)
+    time.sleep(1)


### PR DESCRIPTION
Added initial support for Linux-based OS's to use this. It requires being done in two shell files due to conda behaving oddly without requiring special inputs from the user. Otherwise, it performs as expected. The only required input from a user is `chmod 755 linux-run.sh` once and then `./linux-run.sh` to run the program normally. I commented my code, so hopefully it'll be easy for others to understand what is going on, and add additional features if desired. :)

I also changed relauncher.py to have a 1 seconds delay instead of 0.5 seconds due to buggy behavior trying to close out of the program on Linux. Giving the user 1 second to close before relaunching instead of 0.5 makes this less of an issue.