### PR TITLE
Restored "resize and fill" and "crop and resize".

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -161,7 +161,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                                                                value=3, visible=False)
 
                                     img2img_resize = gr.Radio(label="Resize mode",
-                                                choices=["Just resize"],
+                                                choices=["Just resize", "Crop and resize", "Resize and fill"],
                                                 type="index",
                                                 value=img2img_resize_modes[img2img_defaults['resize_mode']])
 

--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -1192,7 +1192,7 @@ def img2img(prompt: str, image_editor_mode: str, init_info, mask_mode: str, mask
     def init():
         image = init_img.convert("RGB")
         image = resize_image(resize_mode, image, width, height)
-        #image = init_img.convert("RGB")
+        image = image.convert("RGB")
         image = np.array(image).astype(np.float32) / 255.0
         image = image[None].transpose(0, 3, 1, 2)
         image = torch.from_numpy(image)


### PR DESCRIPTION
This re-enables the "resize and fill" and "crop and resize" options, and fixes the resizing so it doesn't break (it works like it did before). The new "uncrop" function is really nowhere near as good due to filling with black rather than the edge colours.