### PR TITLE
FIX: missing closing bracket in webui.cmd

### DIFF
--- a/webui.cmd
+++ b/webui.cmd
@@ -17,8 +17,9 @@ set paths=%paths%;%ProgramData%\anaconda3
 set paths=%paths%;%USERPROFILE%\anaconda3
 
 for %%a in (%paths%) do (
-IF NOT "%custom_conda_path%"=="" (
-  set paths=%custom_conda_path%;%paths%
+ IF NOT "%custom_conda_path%"=="" (
+   set paths=%custom_conda_path%;%paths%
+ )
 )
 
 for %%a in (%paths%) do ( 


### PR DESCRIPTION
Broken syntax is causing the script to output `The system cannot find the file custom-conda-path.txt` even when miniconda is installed in the default path. See hlky/stable-diffusion-webui#558 for example.